### PR TITLE
1단계 api 테스트 완료, orders 모듈 트랜잭션 로직, orders 엔티티 수정

### DIFF
--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -1,13 +1,13 @@
 import { PickType } from '@nestjs/swagger';
 import { Orders } from '../entities/orders.entity';
+import { IsNumber } from 'class-validator';
 
 export class CreateOrderDto extends PickType(Orders, [
-  'o_name',
   'o_tel',
   'o_addr',
   'o_count',
-  'o_total_price',
   'o_req',
-  'o_status',
-  'o_date',
-] as const) {}
+] as const) {
+  @IsNumber()
+  goods_id: number;
+}

--- a/src/orders/entities/orders.entity.ts
+++ b/src/orders/entities/orders.entity.ts
@@ -23,6 +23,10 @@ export class Orders {
   @Column({ unsigned: true })
   user_id: number;
 
+  @IsNumber()
+  @Column({ unsigned: true })
+  goods_id: number;
+
   @IsString()
   @IsNotEmpty()
   @Column()

--- a/src/orders/entities/orders.entity.ts
+++ b/src/orders/entities/orders.entity.ts
@@ -55,7 +55,7 @@ export class Orders {
   //enum으로 바꾸면 좋을 것 같아요
   @IsEnum(Status)
   @IsNotEmpty()
-  @Column({ type: 'enum', enum: Status })
+  @Column({ type: 'enum', enum: Status, default: '주문완료' })
   o_status: Status;
 
   @CreateDateColumn()

--- a/src/orders/entities/ordersdetails.entity.ts
+++ b/src/orders/entities/ordersdetails.entity.ts
@@ -2,7 +2,7 @@ import { IsNumber } from 'class-validator';
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity({ name: 'ordersdetails' })
-export class Ordersdetails {
+export class OrdersDetails {
   @IsNumber()
   @PrimaryGeneratedColumn({ unsigned: true })
   id: number;

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,13 +1,15 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Request } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
+
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
   @Post()
-  purchase(@Body() userId: number, createOrderDto: CreateOrderDto) {
+  purchase(@Request() req, @Body() createOrderDto: CreateOrderDto) {
+    const userId = req.user.id
     return this.ordersService.purchase(userId, createOrderDto);
   }
 

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -7,8 +7,8 @@ export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
   @Post()
-  create(@Body() createOrderDto: CreateOrderDto) {
-    return this.ordersService.create(createOrderDto);
+  purchase(@Body() user_id: number, createOrderDto: CreateOrderDto) {
+    return this.ordersService.purchase(user_id, createOrderDto);
   }
 
   @Get()

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
 
@@ -7,17 +7,8 @@ export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
   @Post()
-  purchase(@Body() user_id: number, createOrderDto: CreateOrderDto) {
-    return this.ordersService.purchase(user_id, createOrderDto);
+  purchase(@Body() userId: number, createOrderDto: CreateOrderDto) {
+    return this.ordersService.purchase(userId, createOrderDto);
   }
 
-  @Get()
-  findAll() {
-    return this.ordersService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.ordersService.findOne(+id);
-  }
 }

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -4,7 +4,7 @@ import { OrdersController } from './orders.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Carts } from './entities/carts.entity';
 import { Orders } from './entities/orders.entity';
-import { Ordersdetails } from './entities/ordersdetails.entity';
+import { OrdersDetails } from './entities/ordersdetails.entity';
 import { Goods } from 'src/goods/entities/goods.entity';
 import { Categories } from 'src/goods/entities/categories.entity';
 import { Stocks } from 'src/goods/entities/stocks.entity';
@@ -18,7 +18,7 @@ import { ReviewController } from './review.controller';
     TypeOrmModule.forFeature([
       Carts,
       Orders,
-      Ordersdetails,
+      OrdersDetails,
       Goods,
       Categories,
       Stocks,

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -9,6 +9,9 @@ import { Goods } from 'src/goods/entities/goods.entity';
 import { Categories } from 'src/goods/entities/categories.entity';
 import { Stocks } from 'src/goods/entities/stocks.entity';
 import { Reviews } from './entities/review.entity';
+import { Users } from 'src/user/entities/user.entitiy';
+import { ReviewService } from './review.service';
+import { ReviewController } from './review.controller';
 
 @Module({
   imports: [
@@ -20,9 +23,10 @@ import { Reviews } from './entities/review.entity';
       Categories,
       Stocks,
       Reviews,
+      Users,
     ]),
   ],
-  providers: [OrdersService],
-  controllers: [OrdersController],
+  providers: [OrdersService, ReviewService],
+  controllers: [OrdersController, ReviewController],
 })
 export class OrdersModule {}

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -16,7 +16,7 @@ export class OrdersService {
   ) {}
 
   async purchase(
-    user_id: number,
+    userId: number,
     createOrderDto: CreateOrderDto, //포스트맨의 body,
   ) {
     const queryRunner = await this.dataSource.createQueryRunner();
@@ -29,7 +29,9 @@ export class OrdersService {
           id: goods_id,
         },
       });
-      // ======굿즈 있는지 없는지 따라 유효성 검사 필요
+      if(!goods) {
+        throw new BadRequestException('존재하지 않는 상품입니다.')
+      }
 
       const quantity = await queryRunner.manager.findOne(Stocks, {
         where: {
@@ -44,10 +46,13 @@ export class OrdersService {
 
       const user = await queryRunner.manager.findOne(Users, {
         where: {
-          id: user_id,
+          id: userId,
         },
       });
-      // ======유저 있는지 없는지 따라 유효성 검사 필요
+
+      if(!user) {
+        throw new BadRequestException('존재하지 않는 유저입니다.')
+      }
 
       const paying = goods.g_price * o_count;
       const afterPaidPoints = user.points - paying;
@@ -61,7 +66,7 @@ export class OrdersService {
       await queryRunner.manager.save(Users, user);
 
       const newOrder = this.ordersRepository.create({
-        user_id,
+        user_id: userId,
         o_name: user.name,
         o_tel,
         o_addr,
@@ -83,11 +88,4 @@ export class OrdersService {
     }
   }
 
-  async findAll() {
-    return `This action returns all goods`;
-  }
-
-  findOne(id: number) {
-    return `This action returns a #${id} good`;
-  }
 }

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,21 +1,86 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { Orders } from './entities/orders.entity';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateOrderDto } from './dto/create-order.dto';
+import { Goods } from 'src/goods/entities/goods.entity';
+import { Stocks } from 'src/goods/entities/stocks.entity';
+import { Users } from 'src/user/entities/user.entitiy';
 
 @Injectable()
 export class OrdersService {
   constructor(
     @InjectRepository(Orders)
-    private odersRepository: Repository<Orders>,
+    private ordersRepository: Repository<Orders>,
+    private readonly dataSource: DataSource,
   ) {}
 
-  async create(createOrderDto: CreateOrderDto) {
-    const newOrder = this.odersRepository.create(createOrderDto);
-    await this.odersRepository.save(newOrder);
+  async purchase(
+    user_id: number,
+    createOrderDto: CreateOrderDto, //포스트맨의 body,
+  ) {
+    const queryRunner = await this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    try {
+      const { o_tel, o_addr, o_count, o_req, goods_id } = createOrderDto;
+      const goods = await queryRunner.manager.findOne(Goods, {
+        where: {
+          id: goods_id,
+        },
+      });
+      // ======굿즈 있는지 없는지 따라 유효성 검사 필요
 
-    return newOrder;
+      const quantity = await queryRunner.manager.findOne(Stocks, {
+        where: {
+          id: goods_id,
+        },
+      });
+      const count = quantity.count - o_count;
+
+      if (count < 0) {
+        throw new BadRequestException('재고가 없습니다.');
+      }
+
+      const user = await queryRunner.manager.findOne(Users, {
+        where: {
+          id: user_id,
+        },
+      });
+      // ======유저 있는지 없는지 따라 유효성 검사 필요
+
+      const paying = goods.g_price * o_count;
+      const afterPaidPoints = user.points - paying;
+      if (afterPaidPoints < 0) {
+        throw new BadRequestException('포인트가 부족합니다.');
+      }
+
+      quantity.count = count;
+      user.points = afterPaidPoints;
+      await queryRunner.manager.save(Stocks, quantity);
+      await queryRunner.manager.save(Users, user);
+
+      const newOrder = this.ordersRepository.create({
+        user_id,
+        o_name: user.name,
+        o_tel,
+        o_addr,
+        o_req,
+        o_count,
+        o_total_price: paying,
+      });
+
+      await this.ordersRepository.save(newOrder);
+      await queryRunner.commitTransaction();
+      await queryRunner.release();
+
+      return newOrder;
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      await queryRunner.release();
+      console.error(err);
+      throw err;
+    }
   }
 
   async findAll() {

--- a/src/orders/review.controller.ts
+++ b/src/orders/review.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Post,
   Get,
-  Put,
   Delete,
   Param,
   Body,
@@ -14,37 +13,37 @@ import { ReviewService } from './review.service';
 export class ReviewController {
   constructor(private readonly reviewService: ReviewService) {}
 
-  @Post(':orders_id')
+  @Post(':ordersId')
   async createReview(
-    @Param('orders_id') orderId: number,
+    @Param('ordersId') ordersId: number,
     @Body() body: { stars: string; review: string },
   ) {
     return await this.reviewService.createReview(
-      orderId,
+      ordersId,
       body.stars,
       body.review,
     );
   }
 
-  @Get(':orders_id')
-  async getReviewByOrderId(@Param('orders_id') orderId: number) {
-    return await this.reviewService.getReviewByOrderId(orderId);
+  @Get(':ordersId')
+  async getReviewByOrderId(@Param('ordersId') ordersId: number) {
+    return await this.reviewService.getReviewByOrderId(ordersId);
   }
 
-  @Patch(':orders_id')
+  @Patch(':ordersId')
   async updateReviewByOrderId(
-    @Param('orders_id') orderId: number,
+    @Param('ordersId') ordersId: number,
     @Body() body: { stars: string; review: string },
   ) {
     return await this.reviewService.updateReviewByOrderId(
-      orderId,
+      ordersId,
       body.stars,
       body.review,
     );
   }
 
-  @Delete(':orders_id')
-  async deleteReviewByOrderId(@Param('orders_id') orderId: number) {
-    return await this.reviewService.deleteReviewByOrderId(orderId);
+  @Delete(':ordersId')
+  async deleteReviewByOrderId(@Param('ordersId') ordersId: number) {
+    return await this.reviewService.deleteReviewByOrderId(ordersId);
   }
 }

--- a/src/orders/review.controller.ts
+++ b/src/orders/review.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Put,
+  Delete,
+  Param,
+  Body,
+  Patch,
+} from '@nestjs/common';
+import { ReviewService } from './review.service';
+
+@Controller('reviews')
+export class ReviewController {
+  constructor(private readonly reviewService: ReviewService) {}
+
+  @Post(':orders_id')
+  async createReview(
+    @Param('orders_id') orderId: number,
+    @Body() body: { stars: string; review: string },
+  ) {
+    return await this.reviewService.createReview(
+      orderId,
+      body.stars,
+      body.review,
+    );
+  }
+
+  @Get(':orders_id')
+  async getReviewByOrderId(@Param('orders_id') orderId: number) {
+    return await this.reviewService.getReviewByOrderId(orderId);
+  }
+
+  @Patch(':orders_id')
+  async updateReviewByOrderId(
+    @Param('orders_id') orderId: number,
+    @Body() body: { stars: string; review: string },
+  ) {
+    return await this.reviewService.updateReviewByOrderId(
+      orderId,
+      body.stars,
+      body.review,
+    );
+  }
+
+  @Delete(':orders_id')
+  async deleteReviewByOrderId(@Param('orders_id') orderId: number) {
+    return await this.reviewService.deleteReviewByOrderId(orderId);
+  }
+}

--- a/src/orders/review.service.ts
+++ b/src/orders/review.service.ts
@@ -11,17 +11,17 @@ export class ReviewService {
   /**
    * 리뷰 작성
    * @param stars
-   * @param orders_id
+   * @param ordersId
    * @param review
    * @returns
    */
   async createReview(
-    orders_id: number,
+    ordersId: number,
     stars: string,
     review: string,
   ): Promise<Reviews> {
     const newReview = await this.reviewRepository.create({
-      orders_id,
+      orders_id: ordersId,
       stars,
       review,
     });
@@ -31,26 +31,26 @@ export class ReviewService {
 
   /**
    * 작성한 리뷰 조회
-   * @param orders_id
+   * @param ordersId
    * @returns
    */
-  async getReviewByOrderId(orders_id: number): Promise<Reviews | undefined> {
-    return await this.reviewRepository.findOne({ where: { orders_id } });
+  async getReviewByOrderId(ordersId: number): Promise<Reviews | undefined> {
+    return await this.reviewRepository.findOne({ where: { orders_id: ordersId } });
   }
 
   /**
    * 리뷰 수정
    * @param stars
-   * @param orders_id
+   * @param ordersId
    * @param review
    * @returns
    */
   async updateReviewByOrderId(
-    orders_id: number,
+    ordersId: number,
     stars: string,
     review: string,
   ): Promise<Reviews | undefined> {
-    const existingReview = await this.getReviewByOrderId(orders_id);
+    const existingReview = await this.getReviewByOrderId(ordersId);
     if (existingReview) {
       existingReview.stars = stars;
       existingReview.review = review;
@@ -59,8 +59,8 @@ export class ReviewService {
     return undefined;
   }
 
-  async deleteReviewByOrderId(orders_id: number): Promise<boolean> {
-    const deleteResult = await this.reviewRepository.delete({ orders_id });
+  async deleteReviewByOrderId(ordersId: number): Promise<boolean> {
+    const deleteResult = await this.reviewRepository.delete({ orders_id: ordersId });
     return deleteResult.affected !== 0;
   }
 }

--- a/src/orders/review.service.ts
+++ b/src/orders/review.service.ts
@@ -1,0 +1,66 @@
+import { Repository } from 'typeorm';
+import { Reviews } from './entities/review.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+
+export class ReviewService {
+  constructor(
+    @InjectRepository(Reviews)
+    private reviewRepository: Repository<Reviews>,
+  ) {}
+
+  /**
+   * 리뷰 작성
+   * @param stars
+   * @param orders_id
+   * @param review
+   * @returns
+   */
+  async createReview(
+    orders_id: number,
+    stars: string,
+    review: string,
+  ): Promise<Reviews> {
+    const newReview = await this.reviewRepository.create({
+      orders_id,
+      stars,
+      review,
+    });
+    console.log(newReview);
+    return await this.reviewRepository.save(newReview);
+  }
+
+  /**
+   * 작성한 리뷰 조회
+   * @param orders_id
+   * @returns
+   */
+  async getReviewByOrderId(orders_id: number): Promise<Reviews | undefined> {
+    return await this.reviewRepository.findOne({ where: { orders_id } });
+  }
+
+  /**
+   * 리뷰 수정
+   * @param stars
+   * @param orders_id
+   * @param review
+   * @returns
+   */
+  async updateReviewByOrderId(
+    orders_id: number,
+    stars: string,
+    review: string,
+  ): Promise<Reviews | undefined> {
+    const existingReview = await this.getReviewByOrderId(orders_id);
+    if (existingReview) {
+      existingReview.stars = stars;
+      existingReview.review = review;
+      return await this.reviewRepository.save(existingReview);
+    }
+    return undefined;
+  }
+
+  async deleteReviewByOrderId(orders_id: number): Promise<boolean> {
+    const deleteResult = await this.reviewRepository.delete({ orders_id });
+    return deleteResult.affected !== 0;
+  }
+}

--- a/src/orders/review.service.ts
+++ b/src/orders/review.service.ts
@@ -25,7 +25,6 @@ export class ReviewService {
       stars,
       review,
     });
-    console.log(newReview);
     return await this.reviewRepository.save(newReview);
   }
 

--- a/src/orders/types/order.type.ts
+++ b/src/orders/types/order.type.ts
@@ -2,6 +2,6 @@ export enum Status {
   Orderdone = '주문완료',
   Intransit = '배송중',
   Deliverydone = '배송완료',
-  Odercancle = '주문취소',
-  Deliverycancle = '배송취소',
+  Odercancel = '주문취소',
+  Deliverycancel = '배송취소',
 }

--- a/src/user/dto/sign_in.dto.ts
+++ b/src/user/dto/sign_in.dto.ts
@@ -1,4 +1,4 @@
 import { PickType } from "@nestjs/swagger";
 import { Users } from "../entities/user.entitiy";
 
-export class Sign_inDto extends PickType(Users, ["password", "email"]) {}
+export class SignInDto extends PickType(Users, ["password", "email"]) {}

--- a/src/user/dto/update.dto.ts
+++ b/src/user/dto/update.dto.ts
@@ -1,7 +1,7 @@
 import { PickType } from "@nestjs/swagger";
 import { Users } from "../entities/user.entitiy";
 
-export class updateDto extends PickType(Users, [
+export class UpdateDto extends PickType(Users, [
   "nickname",
   "profile",
   "password",

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -11,9 +11,9 @@ import {
 } from "@nestjs/common";
 import { UserService } from "./users.service";
 import { SignUpDto } from "./dto/signup.dto";
-import { Sign_inDto } from "./dto/sign_in.dto";
+import { SignInDto } from "./dto/sign_in.dto";
 import { Users } from "./entities/user.entitiy";
-import { updateDto } from "./dto/update.dto";
+import { UpdateDto } from "./dto/update.dto";
 
 @Controller("users")
 export class UserController {
@@ -26,8 +26,8 @@ export class UserController {
   }
 
   @Post("login")
-  async signin(@Body() sign_inDto: Sign_inDto, @Res() res) {
-    const user = await this.userService.sign_in(sign_inDto);
+  async signin(@Body() signInDto: SignInDto, @Res() res) {
+    const user = await this.userService.signIn(signInDto);
     res.cookie("authorization", `Bearer ${user.accessToken}`);
     return res.status(HttpStatus.OK).json({
       message: "로그인 완료 ",
@@ -46,7 +46,7 @@ export class UserController {
   }
 
   @Patch("update/:id")
-  async update(@Param("id") id: number, @Body() UpdateDto: updateDto) {
+  async update(@Param("id") id: number, @Body() UpdateDto: UpdateDto) {
     await this.userService.update(+id, UpdateDto);
     return { message: "수정되었습니다" };
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -26,7 +26,7 @@ export class UserController {
   }
 
   @Post("login")
-  async signin(@Body() signInDto: SignInDto, @Res() res) {
+  async signIn(@Body() signInDto: SignInDto, @Res() res) {
     const user = await this.userService.signIn(signInDto);
     res.cookie("authorization", `Bearer ${user.accessToken}`);
     return res.status(HttpStatus.OK).json({
@@ -46,8 +46,8 @@ export class UserController {
   }
 
   @Patch("update/:id")
-  async update(@Param("id") id: number, @Body() UpdateDto: UpdateDto) {
-    await this.userService.update(+id, UpdateDto);
+  async update(@Param("id") id: number, @Body() updateDto: UpdateDto) {
+    await this.userService.update(+id, updateDto);
     return { message: "수정되었습니다" };
   }
 

--- a/src/user/users.service.ts
+++ b/src/user/users.service.ts
@@ -11,8 +11,8 @@ import { Users } from "./entities/user.entitiy";
 import { compare, hash } from "bcrypt";
 import _ from "lodash";
 import { SignUpDto } from "./dto/signup.dto";
-import { Sign_inDto } from "./dto/sign_in.dto";
-import { updateDto } from "./dto/update.dto";
+import { SignInDto } from "./dto/sign_in.dto";
+import { UpdateDto } from "./dto/update.dto";
 import { JwtService } from "@nestjs/jwt";
 
 @Injectable()
@@ -24,14 +24,14 @@ export class UserService {
   ) {}
 
   async register(signUpDto: SignUpDto): Promise<Users> {
-    const find_email = await this.findByEmail(signUpDto.email);
-    if (find_email) {
+    const findEmail = await this.findByEmail(signUpDto.email);
+    if (findEmail) {
       throw new ConflictException("이미 가입된 이메일 입니다.");
     }
-    const hashed_password = await hash(signUpDto.password, 10);
+    const hashedPassword = await hash(signUpDto.password, 10);
     const user = await this.usersRepository.save({
       email: signUpDto.email,
-      password: hashed_password,
+      password: hashedPassword,
       name: signUpDto.name,
       nickname: signUpDto.nickname,
       profile: signUpDto.profile,
@@ -39,16 +39,16 @@ export class UserService {
     return user;
   }
 
-  async sign_in(sign_inDto: Sign_inDto) {
+  async signIn(signInDto: SignInDto) {
     const user = await this.usersRepository.findOne({
       select: ["id", "email", "password", "nickname", "profile", "name"],
-      where: { email: sign_inDto.email },
+      where: { email: signInDto.email },
     });
     if (_.isNull(user)) {
       throw new UnauthorizedException("이메일을 확인하세요.");
     }
-    const compared_password = await compare(sign_inDto.password, user.password);
-    if (!compared_password) {
+    const comparedPassword = await compare(signInDto.password, user.password);
+    if (!comparedPassword) {
       throw new UnauthorizedException("비밀번호를 확인하세요.");
     }
     const payload = { email: user.email, sub: user.id };
@@ -89,7 +89,7 @@ export class UserService {
     return user;
   }
 
-  async update(id: number, updateDto: updateDto) {
+  async update(id: number, updateDto: UpdateDto) {
     const user = await this.usersRepository.findOne({
       where: { id },
     });


### PR DESCRIPTION
## 모듈명
orders
### 하위 계층/함수/엔티티 명(공란가능)
1. orders.entity.ts
2. orders.controller.ts >> 매개변수에 @Request()를 추가하여 ExecutionContext에서 req.user.id 추출 로직 구축
3. orders.service.ts >> purchase 함수 
   >> goods 상수를 찾는 로직에 relation: ['stock']을 추가하여 한 번에 goods 엔티티와 연관된 stock 엔티티를 모두 조회하도록 
         로직 변경 + Stocks 엔티티 데이터 행 관리 로직을 '생성/갱신(save)'에서 '갱신(update)'로 변경 + orders엔티티에 order
        정보 추가할 때 goods_id도 등록돼 goods엔티티와 맵핑될 수 있도록 로직 수정

### 변경 사유
1. orders.entity.ts: goods_id 컬럼 추가(goods 엔티티의 id를 받아와 외래키를 연결하기 위함)
5. 

