### PR TITLE
토스 페이먼츠 중복 결제 방지 로직 개선

### DIFF
--- a/client/src/components/OrderPage copy.txt
+++ b/client/src/components/OrderPage copy.txt
@@ -1,0 +1,180 @@
+<template>
+  <div class="order-page">
+    <h1>주문 확인</h1>
+    <div>
+      <h2>주문내역</h2>
+      <table class="default">
+        <tbody>
+          <tr v-if="orderInfo">
+            <th>이름</th>
+            <td>{{ orderInfo.name }}</td>
+          </tr>
+          <tr v-if="orderInfo">
+            <th>이메일</th>
+            <td>{{ orderInfo.email }}</td>
+          </tr>
+          <tr>
+            <th>휴대폰 번호</th>
+            <td>{{ orderInfo.o_tel }}</td>
+          </tr>
+          <tr>
+            <th>배송주소</th>
+            <td>{{ orderInfo.o_detail_addr }}</td>
+          </tr>
+          <tr>
+            <th>총액</th>
+            <td>{{ orderInfo.o_total_price }}원</td>
+          </tr>
+          <tr>
+            <th>주문번호</th>
+            <td>{{ orderInfo.id }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+<table class ="default">
+<thead>
+  <tr>
+    <th colspan="2">주문 상세</th>
+  </tr>
+</thead>
+  <tr v-for="detail in orderDetails" :key="detail.goods_id">
+    <td>
+
+        <tbody>
+        <tr>
+          <th>상품명</th>
+          <td>{{ detail.g_name }}</td>
+        </tr>
+        <tr>
+          <th>상품 번호</th>
+          <td>{{ detail.goods_id }}</td>
+        </tr>
+        <tr>
+          <th>주문 수량</th>
+          <td>{{ detail.od_count }}</td>
+        </tr>
+      </tbody>
+    </td>
+  </tr>
+</table>
+
+    <div class="order-btn">
+      <button class="button-cash-purchase" v-if="!orderInfo.tossOrderId">
+        주문 취소
+      </button>
+      <button
+        class="button-cash-purchase"
+        v-if="!orderInfo.tossOrderId"
+        @click="handleCashPurchase"
+      >
+        포인트로 구매
+      </button>
+      <button
+        class="button-cash-purchase"
+        @click="handleCashPurchase"
+      >
+        현금 구매
+      </button>
+      <button class="button-cash-purchase" v-if="orderInfo.tossOrderId" 
+      @click=" handleCashPaymentCancel">
+        결제 취소
+      </button>
+      <button class="button-cash-purchase" v-if="orderInfo.tossOrderId" @click="handleCheckShipping">
+        배송 확인
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+export default {
+  name: 'OrderPage',
+  data() {
+    return {
+      orderInfo: {},
+      orderDetails: [],
+    };
+  },
+  created() {
+    this.fetchOrderInfo();
+  },
+  methods: {
+    async fetchOrderInfo() {
+      try {
+        const orderId = 100622;
+        const token =
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjk5MzE4LCJpYXQiOjE3MTQyOTkyODgsImV4cCI6MTc1NzQ5OTI4OH0.J31KF96C-EnnIel6p9iX2K7k7ujggDRFvxrephRRK-k';
+        const response = await axios.get(`${process.env.VUE_APP_API_URL}/api/orders/${orderId}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (response.data) {
+          this.orderInfo = response.data[0];
+        }
+
+        const responseDetails = await fetch(`${process.env.VUE_APP_API_URL}/api/orders/details/${orderId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        const data = await responseDetails.json();
+        if(data) {
+
+        this.orderDetails = data;
+        }
+      } catch (error) {
+        console.error('주문 상세를 불러오는 데 실패했습니다', error);
+      }
+    },
+    async handleCashPaymentCancel() {
+      const orderId = 100622;
+      await axios.get(`${process.env.VUE_APP_API_URL}/api/payments/${orderId}/cancelCash`)
+      return console.log('삭제되었습니다.')
+    },
+    handleCashPurchase() {
+      this.$router.push({ name: 'payCash' });
+    },
+    handleCheckShipping(){
+      this.$router.push({name: 'OrderShipping'});
+    }
+  }
+};
+</script>
+
+<style>
+.button-cash-purchase {
+  background-color: #4caf50; /* 녹색 배경 */
+  color: white; /* 흰색 텍스트 */
+  padding: 10px 20px; /* 상하 10px, 좌우 20px 패딩 */
+  border: none; /* 테두리 없음 */
+  border-radius: 5px; /* 모서리 둥글게 */
+  cursor: pointer; /* 마우스 오버 시 커서 변경 */
+  transition: all 0.3s; /* 부드러운 전환 효과 */
+}
+
+.button-cash-purchase:hover {
+  background-color: #45a049; /* 마우스 오버 시 배경색 변경 */
+}
+
+.order-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+.order-page>div {
+    margin: 5px 0;
+}
+.order-btn {
+    display: flex;
+}
+.order-btn > button {
+  margin: 0 5px;
+}
+</style>

--- a/client/src/components/PayCashValidation.vue
+++ b/client/src/components/PayCashValidation.vue
@@ -125,8 +125,8 @@ export default {
         await paymentWidget.requestPayment({
           orderId: `${orderId}`,
           orderName: `${orderName}`,
-          successUrl: 'http://potato-shop.shop/payments/payCashValidationSuccess',
-          failUrl: 'http://potato-shop.shop/api/fail',
+          successUrl: `${process.env.VUE_APP_CLIENT_URL}/payments/payCashValidationSuccess`,
+          failUrl: `${process.env.VUE_APP_API_URL}/api/fail`,
         });
       });
     },

--- a/client/src/components/PayCashValidationSuccess.vue
+++ b/client/src/components/PayCashValidationSuccess.vue
@@ -112,6 +112,23 @@ export default {
 
       const confirmedJson = await confirm.json();
 
+      if(confirmedJson) {
+        const lastTransactionKey = confirmedJson.lastTransactionKey
+        const orderId = confirmedJson.orderId
+        const transactionData = {
+          lastTransactionKey,
+          orderId
+        }
+
+       await fetch(process.env.VUE_APP_API_URL+'/api/payments/payCash-wrapUp', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(transactionData),
+      });
+      }
+
       // TODO: 결제 성공 비즈니스 로직을 구현하세요.
       // console.log(json);
       return confirmedJson;
@@ -120,6 +137,24 @@ export default {
       document.getElementById('response').innerHTML =
         `<pre>${JSON.stringify(data, null, 4)}</pre>`;
     });
+
+    // PayCashValidationSuccess().then(function(data) {
+    //   const confirmedJson = JSON.stringify(data)
+    //     const lastTransactionKey = confirmedJson.lastTransactionKey
+    //     const orderId = confirmedJson.orderId
+    //     const transactionData = {
+    //       lastTransactionKey,
+    //       orderId
+    //     }
+
+    //    fetch(process.env.VUE_APP_API_URL+'/api/payments/payCash-wrap', {
+    //     method: 'POST',
+    //     headers: {
+    //       'Content-Type': 'application/json',
+    //     },
+    //     body: JSON.stringify(transactionData),
+    //   });      
+    // })
 
     const paymentKeyElement = document.getElementById('paymentKey');
     const orderIdElement = document.getElementById('orderId');

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -26,10 +26,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
   private static extractJWT(req: RequestType): string | null {
-    console.log('국밥철도999', req.cookies)
     // const { authorization } = req.cookies;
     const {accessToken} = req.cookies;
-        console.log('국밥55', accessToken);
     if (accessToken) {
       const [tokenType, token] = accessToken.split(' ');
       if (tokenType !== 'Bearer')

--- a/src/payments/entities/tossHistory.entity.ts
+++ b/src/payments/entities/tossHistory.entity.ts
@@ -1,5 +1,5 @@
 import { IsBoolean, IsEnum, IsNotEmpty, IsNumber, IsString } from "class-validator";
-import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 import { PayMethod } from "../types/payments.type";
 import { Orders } from "../../orders/entities/orders.entity";
 import { UpdateCommentDto } from "src/boards/dto/update-comment.dto";
@@ -18,9 +18,17 @@ export class TossHistory {
     @Column({ unsigned: true })
     orders_id: number;
 
-    @IsNumber()
+    @IsString()
     @Column()
     toss_orders_id: string;
+
+    @IsString()
+    @Column({nullable: true})
+    toss_transaction_key: string;
+
+    @IsString()
+    @Column({nullable: true})
+    toss_payment_key: string;
 
     @IsNumber()
     @IsNotEmpty()
@@ -44,7 +52,7 @@ export class TossHistory {
     @UpdateDateColumn()
     updated_at: Date;
 
-    @OneToOne(() => Orders, (orders) => orders.payments)
+    @ManyToOne(() => Orders, (orders) => orders.payments)
     @JoinColumn({ name: 'orders_id', referencedColumnName: 'id' })
     orders: Orders;
 

--- a/src/payments/payments.controller.ts
+++ b/src/payments/payments.controller.ts
@@ -62,6 +62,14 @@ export class PaymentsController {
         message: '결제 준비가 완료되었습니다.' 
     })
    }
+   //토스페이 결제 마지막 마무리
+   @Post('payCash-wrapUp')
+   async payCashWrapUp(@Body() transactionData) {
+    console.log('구웃밥1', transactionData)
+    const data = await this.paymentsService.payCashWrapUp(transactionData)
+
+    return data
+   }
 
     // 유저 결제 목록 전체 조회
     @UseGuards(AuthGuard('jwt'))
@@ -112,30 +120,32 @@ export class PaymentsController {
         }
     }
 
-    // 결제 취소
-    // @UseGuards(AuthGuard('jwt'))
-    // @Post(':toss_orders_id/cancelCash')
-    // async cancelPayCash(@Req() req, @Param('toss_orders_id') toss_orders_id: number) {
-    //     try {
-    //         // 결제 취소 로직을 서비스에서 호출하여 실행.
-    //         const userId = req.user.id
+    //토스 결제 취소
+    @UseGuards(AuthGuard('jwt'))
+    @Get(':orders_id/cancelCash')
+    async cancelPayCash(@Req() req, @Param() orders_id: string) {
+        try {
+            // 결제 취소 로직을 서비스에서 호출하여 실행.
 
-    //         logger.traceLogger(`Payments - cancelPay`, `req.user = ${JSON.stringify(req.user)}, toss_orders_id = ${toss_orders_id}`)
-    //         const cancelledPay = await this.paymentsService.cancelPay(userId, toss_orders_id);
+            const userId = req.user.id
+            console.log('토스 결제 취소1', userId, orders_id)
 
-    //         return { message: '결제가 취소되었습니다.', payments: cancelledPayCash };
-    //     } catch (error) {
-    //         console.error(error)
-    //         if (error instanceof NotFoundException) {
-    //             throw error;
-    //         } else {
-    //             const fatalError = new NotFoundException('알 수 없는 에러가 발생하여 결제를 취소할 수 없습니다.');
-    //             logger.fatalLogger(fatalError, `req.user = ${JSON.stringify(req.user)}, paymentsId = ${toss_orders_id}`)
-    //             throw fatalError// 그 외의 오류는 일반적인 오류 메시지를 반환.
-    //         }
-    //     }
-    //     //https://api.tosspayments.com/v1/payments/{paymentKey}/cancel로 렌더링 해야 함
-    // }
+            logger.traceLogger(`Payments - cancelPay`, `req.user = ${JSON.stringify(req.user)}, orders_id = ${orders_id}`)
+            const data = await this.paymentsService.cancelPayCash(userId, orders_id);
+
+            return { message: '결제가 취소되었습니다.', data };
+        } catch (error) {
+            console.error(error)
+            if (error instanceof NotFoundException) {
+                throw error;
+            } else {
+                const fatalError = new NotFoundException('알 수 없는 에러가 발생하여 결제를 취소할 수 없습니다.');
+                logger.fatalLogger(fatalError, `req.user = ${JSON.stringify(req.user)}, orders_id = ${orders_id}`)
+                throw fatalError// 그 외의 오류는 일반적인 오류 메시지를 반환.
+            }
+        }
+    }
+
 
     @Get('/find-location')
     async findLocation(@Query('address') address: string, @Res() res: Response) {

--- a/src/payments/payments.service.ts
+++ b/src/payments/payments.service.ts
@@ -22,6 +22,7 @@ import { RedisService } from '../redis/redis.service';
 import { KakaoGeocoder } from '../common/utils/kakao-geocoder.util';
 import { TossHistory } from './entities/tossHistory.entity';
 import { faker } from '@faker-js/faker';
+import axios from 'axios';
 
 @Injectable()
 export class PaymentsService {
@@ -261,12 +262,21 @@ export class PaymentsService {
     }
 
     const existingTrial = await this.tossRepository.findOneBy({orders_id})
+    console.log('토스 1', existingTrial)
     if(existingTrial && existingTrial.p_total_price == 0 && existingTrial.p_status == false) {
       const data = existingTrial
+
+      console.log('토스 2', existingTrial)
       return {
         message:  `${order.ordersdetails[0].goods_id}번 상품 외 ${order.ordersdetails.length - 1} 건`,
         data
       }
+    }
+
+    if(existingTrial && existingTrial.toss_transaction_key && existingTrial.p_total_price !== 0 && existingTrial.p_status) {
+
+      console.log('토스 3', existingTrial)
+      throw new BadRequestException('이미 결제된 내역입니다.')
     }
 
 
@@ -277,10 +287,6 @@ export class PaymentsService {
       toss_orders_id = faker.string.alphanumeric(10);
       duplicate = await this.tossRepository.findOneBy({ toss_orders_id });
     } while (!_.isNil(duplicate));
-    console.log('페이먼츠 국밥2');
-
-    console.log('페이먼츠 국밥3', orders_id);
-
 
     const data = this.tossRepository.create({
       user_id: userId,
@@ -322,7 +328,6 @@ export class PaymentsService {
       .leftJoinAndSelect('toss.orders', 'orders')
       .where('toss.toss_orders_id = :orderId', { orderId })
       .getOne();
-    console.log('토스 국밥1', tossPayment);
     if (!tossPayment) {
       const error = new BadRequestException('존재하지 않는 주문입니다.');
       logger.errorLogger(error, `requestData = ${JSON.stringify(requestData)}`);
@@ -388,7 +393,6 @@ export class PaymentsService {
         }
 
         tossPayment.p_total_price = tossPayment.o_total_price;
-        tossPayment.p_status = true;
 
         await queryRunner.manager.save(TossHistory, tossPayment);
 
@@ -419,6 +423,31 @@ export class PaymentsService {
       }
     }
   }
+
+   //토스페이 결제 마지막 마무리
+   async payCashWrapUp(transactionData) {
+    console.log('구웃밥2', transactionData)
+    const {orderId, lastTransactionKey} = transactionData
+    const data = await this.tossRepository.findOne({
+      where: {
+        toss_orders_id: orderId
+      }
+    })
+    if(_.isNil(data) || !data.p_status || !data.toss_payment_key) {
+      const fatalError = new InternalServerErrorException('PG 결제 과정에서 알 수 없는 오류가 발생하였습니다.')
+      logger.fatalLogger(fatalError, `data = ${JSON.stringify(data)}, transactionData = ${JSON.stringify(transactionData)}`)
+      throw fatalError
+    }
+    
+
+    const result = await this.tossRepository.update({toss_orders_id: orderId}, {toss_transaction_key: lastTransactionKey})
+
+    return {
+        message: '토스로부터 결제 정보를 수신받았습니다.',
+        data: result
+    }
+   }
+
 
   // 유저별 결제 목록 전체 조회
   async findAllOrderbyUser(userId: number): Promise<Payments[]> {
@@ -611,6 +640,57 @@ export class PaymentsService {
       throw fatalError;
     }
   }
+
+
+   //토스 결제 취소
+   async cancelPayCash(userId, orders_id) {
+       try {
+           // 결제 취소 로직을 서비스에서 호출하여 실행.
+           const {orders_id: number} = orders_id
+          console.log('토스 결제 취소2')
+           const transaction = await this.tossRepository.findOne({
+            where: {
+              user_id: userId,
+              orders_id: number
+            }
+           });
+           console.log('토스 결제 취소2-1', transaction)
+           const cancelReason = {cancelReason: "고객이 취소를 원함"}
+           const secretKey = 'test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6';
+           const encryptedSecretKey = 'Basic ' + Buffer.from(secretKey + ':').toString('base64');
+          const data = await axios.post(`https://api.tosspayments.com/v1/payments/${transaction.toss_payment_key}/cancel`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': encryptedSecretKey
+            },
+            data: JSON.stringify(cancelReason),
+           })
+           const response = data.data
+           const result = await this.tossRepository.insert({
+            user_id: transaction.user_id,
+            orders_id: transaction.orders_id,
+            toss_orders_id: transaction.toss_orders_id,
+            toss_transaction_key: response.toss_transaction_key,
+            toss_payment_key: transaction.toss_payment_key,
+            o_total_price: transaction.o_total_price,
+            p_total_price: -transaction.p_total_price,
+            p_status: true,
+           }) 
+           console.log('토스 결제 취소3', response)
+           return { message: '결제가 취소되었습니다.', data: result };
+       } catch (error) {
+           console.error(error)
+           if (error instanceof NotFoundException) {
+               throw error;
+           } else {
+               const fatalError = new NotFoundException('알 수 없는 에러가 발생하여 결제를 취소할 수 없습니다.');
+               logger.fatalLogger(fatalError, `req.user = ${userId}, orders_id = ${orders_id}`)
+               throw fatalError// 그 외의 오류는 일반적인 오류 메시지를 반환.
+           }
+       }
+   }
+
 
   /**
    * 주소로 좌표찾기

--- a/src/toss/toss.service.ts
+++ b/src/toss/toss.service.ts
@@ -16,9 +16,11 @@ export class TossService {
   async confirmPayment({ paymentKey, orderId, amount }): Promise<any> {
     const encryptedSecretKey = 'Basic ' + Buffer.from(this.secretKey + ':').toString('base64');
     const data = await this.tossRepository.findOneBy({toss_orders_id:orderId})
-    if(data.p_status == true) {
+    console.log('토스국밥', data)
+    if(data.p_status) {
       throw new BadRequestException('이미 결제된 내역입니다.')
     }
+    await this.tossRepository.update({toss_orders_id: orderId}, {p_status: true, toss_payment_key: paymentKey})
     
     return axios.post(this.baseUrl, {
       orderId: orderId,


### PR DESCRIPTION
## 모듈명
토스 페이먼츠
### 하위 함수 명(공란가능)
중복 결제를 방지하였고, 결제 취소 기능이 도입될 것을 감안하여 tossHistory 테이블과 orders 테이블 간 관계를 다대일로 바꿈
tossHistory 테이블에 toss_payment_key 컬럼을 추가하여 인증 절차 중간에 paymentKey가 발급되었을 때 이를 추가하도록 해 이후의 보안을 강화해보고자 시도하였음

토스 페이먼츠로부터 최종 결제 승인이 왔을 때 함께 오는 lastTransaction key를 컬럼에 입력하도록 로직과 컬럼을 추가하여 해당 결제가 문제 없이 결제가 끝난 것인지 육안으로 확인이 가능하도록 개선하였음.

현재 토스 페이먼츠 결제 취소 로직 구현중이나, 알 수 없는 이유로 시크릿 키가 인식되지 않음.

### 변경 사유
ex) 브랜치 생성
